### PR TITLE
Add Linux note to "get notified" button

### DIFF
--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -92,7 +92,7 @@
                                         padding: 2% 3%;
                                         font-size:200%;
                                         width: 94%; ">
-                    <strong>iOS, Android &amp; more</strong>
+                    <strong>iOS, Android, Linux &amp; more</strong>
                     Sign up to be notified...
                 </a>
             </div>
@@ -183,7 +183,7 @@
                                         padding: 2% 3%;
                                         font-size:120%;
                                         width: 94%; ">
-                    <strong>iOS, Android &amp; more</strong>
+                    <strong>iOS, Android, Linux &amp; more</strong>
                     Sign up to be notified...
                 </a>
             </div>


### PR DESCRIPTION
Since there's a Linux version in the works, that shouldn't be hidden on the prominent "keep me informed" front page button, and it doesn't impede the design to do so.