### PR TITLE
Change About link in footer, links to about.html

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -130,7 +130,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/FAQ.html
+++ b/public/FAQ.html
@@ -385,7 +385,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/Payments_FAQ.html
+++ b/public/Payments_FAQ.html
@@ -361,7 +361,7 @@ After 3 attempts to initiate the verification process with the site owner, the e
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/about.html
+++ b/public/about.html
@@ -890,7 +890,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/about_ad_replacement.html
+++ b/public/about_ad_replacement.html
@@ -198,7 +198,7 @@ Replacing ads means our users get a share of the gross ad revenue. Brave will pa
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/android_privacy.html
+++ b/public/android_privacy.html
@@ -240,7 +240,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/base.html
+++ b/public/base.html
@@ -148,7 +148,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/blogpost_1.html
+++ b/public/blogpost_1.html
@@ -243,7 +243,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/blogpost_2.html
+++ b/public/blogpost_2.html
@@ -260,7 +260,7 @@ This week I’d like to dive into the details of how Brave will achieve these go
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/blogpost_3.html
+++ b/public/blogpost_3.html
@@ -253,7 +253,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/blogpost_4.html
+++ b/public/blogpost_4.html
@@ -240,7 +240,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/blogpost_5.html
+++ b/public/blogpost_5.html
@@ -258,7 +258,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/brave_android_welcome.html
+++ b/public/brave_android_welcome.html
@@ -232,7 +232,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/brave_youth_program.html
+++ b/public/brave_youth_program.html
@@ -276,7 +276,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/dev_timeline.html
+++ b/public/dev_timeline.html
@@ -163,7 +163,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/downloads.html
+++ b/public/downloads.html
@@ -280,7 +280,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/index.html
+++ b/public/index.html
@@ -370,7 +370,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/ios_privacy.html
+++ b/public/ios_privacy.html
@@ -189,7 +189,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -216,7 +216,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/publishers.html
+++ b/public/publishers.html
@@ -259,7 +259,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/public/terms_of_use.html
+++ b/public/terms_of_use.html
@@ -248,7 +248,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -148,7 +148,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                             <a href="/brave_youth_program.html">Youth Program</a>
                         </div>
                         <div>
-                            <a href="/about.html#team">About Us</a>
+                            <a href="/about.html">About Us</a>
                         </div>
 
                         <div>


### PR DESCRIPTION
- About Us in the page footer links to about.html, removed `#team`

Fixes #144