### PR TITLE
Update CSP directives

### DIFF
--- a/server.js
+++ b/server.js
@@ -191,7 +191,14 @@ server.route({
     },
     plugins: {
       blankie: {
-        frameAncestors: 'chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd'
+        frameAncestors: 'chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd',
+        defaultSrc: '\'self\'',
+        styleSrc: '\'unsafe-inline\' https://fonts.googleapis.com/ \'self\'',
+        scriptSrc: '\'unsafe-inline\' *.brave.com \'self\'',
+        fontSrc: 'https://fonts.gstatic.com data: \'self\'',
+        imgSrc:  '*.brave.com \'self\'',
+        // don't generate nonces automatically
+        generateNonces: false
       }
     }
   },


### PR DESCRIPTION
Auditors: @diracdeltas

I think blankie introduced those and default-src=none was being applied for all src instances
CSP warnings were blocking scripts and making website unable to navigate.