### PR TITLE
Removed listing for Android QA since the role is filled

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -845,12 +845,6 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                                 Senior Software Engineer &ndash; Android<br>
                             </a>
                         </li>
-                        <li>
-                             <a href="#careers">
-                                <strong>January 5, 2017</strong><br>
-                                QA Engineer &ndash; Android<br>
-                            </a>
-                        </li>
 
 <!--
                         <li>
@@ -882,18 +876,6 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
 </p>
                     <p>Applications will be considered for both on-location (San Francisco) and remote telecommute (within USA and Canada, if known remote performer).</p>
                     <p><a href="/assets/jobs/Brave_SeniorSoftwareEngineer_Android.pdf" target="_blank">View the full job description...</a></p>
-                </div>
-
-                <div class="news-v3-in-sm no-padding">
-                    <ul class="list-inline posted-info">
-                        <li>Brave Software</li>
-                        <li>Posted January 5, 2017</li>
-                    </ul>
-                    <h2>QA Engineer &ndash; Android</h2>
-                    <p>Brave is looking for an experienced Android-focused QA Engineer to work on our latest Chromium-based Android browser.
-</p>
-                    <p>Applications will be considered for both on-location (San Francisco) and remote telecommute (within USA and Canada, if known remote performer).</p>
-                    <p><a href="/assets/jobs/Brave_QualityAssuranceEngineer_Android.pdf" target="_blank">View the full job description...</a></p>
                 </div>
 
             </div>


### PR DESCRIPTION
Removed the listing for the QA role on the about page.