### PR TITLE
add battle-for-the-net widget

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -845,6 +845,12 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
                                 Senior Software Engineer &ndash; Android<br>
                             </a>
                         </li>
+                        <li>
+                             <a href="#careers">
+                                <strong>January 5, 2017</strong><br>
+                                QA Engineer &ndash; Android<br>
+                            </a>
+                        </li>
 
 <!--
                         <li>
@@ -876,6 +882,18 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
 </p>
                     <p>Applications will be considered for both on-location (San Francisco) and remote telecommute (within USA and Canada, if known remote performer).</p>
                     <p><a href="/assets/jobs/Brave_SeniorSoftwareEngineer_Android.pdf" target="_blank">View the full job description...</a></p>
+                </div>
+
+                <div class="news-v3-in-sm no-padding">
+                    <ul class="list-inline posted-info">
+                        <li>Brave Software</li>
+                        <li>Posted January 5, 2017</li>
+                    </ul>
+                    <h2>QA Engineer &ndash; Android</h2>
+                    <p>Brave is looking for an experienced Android-focused QA Engineer to work on our latest Chromium-based Android browser.
+</p>
+                    <p>Applications will be considered for both on-location (San Francisco) and remote telecommute (within USA and Canada, if known remote performer).</p>
+                    <p><a href="/assets/jobs/Brave_QualityAssuranceEngineer_Android.pdf" target="_blank">View the full job description...</a></p>
                 </div>
 
             </div>

--- a/public/assets/js/widget.js
+++ b/public/assets/js/widget.js
@@ -1,0 +1,178 @@
+(function() {
+  if (typeof _bftn_options == "undefined") _bftn_options = {};
+  if (typeof _bftn_options.iframe_base_path == "undefined") _bftn_options.iframe_base_path = 'https://widget.battleforthenet.com/iframe';
+  if (typeof _bftn_options.animation == "undefined") _bftn_options.animation = 'main';
+  if (typeof _bftn_options.delay == "undefined") _bftn_options.delay = 1000;
+  if (typeof _bftn_options.debug == "undefined") _bftn_options.debug = false;
+  if (typeof _bftn_options.date == "undefined") _bftn_options.date = new Date(2017, 6 /* Zero-based month */, 12);
+  if (typeof _bftn_options.always_show_widget == "undefined") _bftn_options.always_show_widget = false;
+
+  var _bftn_animations = {
+    main: {
+      options: {
+        modalAnimation: 'main'
+      },
+      init: function(options) {
+        for (var k in options) this.options[k] = options[k];
+        return this;
+      },
+      start: function() {
+        var iframe = _bftn_util.createIframe();
+        _bftn_util.bindIframeCommunicator(document.getElementById('_bftn_iframe'), this);
+      },
+      stop: function() {
+        _bftn_util.destroyIframe();
+      }
+    }
+  }
+
+  var _bftn_util = {
+    injectCSS: function(id, css) {
+      var style = document.createElement('style');
+      style.type = 'text/css';
+      style.id = id;
+      if (style.styleSheet) style.styleSheet.cssText = css;
+      else style.appendChild(document.createTextNode(css));
+      document.head.appendChild(style);
+    },
+
+    createIframe: function() {
+      var wrapper = document.createElement('div');
+      wrapper.id = '_bftn_wrapper';
+      var iframe = document.createElement('iframe');
+      iframe.id = '_bftn_iframe';
+      iframe.src = _bftn_options.iframe_base_path + '/iframe.html';
+      iframe.frameBorder = 0;
+      iframe.allowTransparency = true; 
+      iframe.style.display = 'none';
+      wrapper.appendChild(iframe);
+      document.body.appendChild(wrapper);
+      return wrapper;
+    },
+
+    destroyIframe: function() {
+      var iframe = document.getElementById('_bftn_wrapper');
+      iframe.parentNode.removeChild(iframe);
+    },
+
+    bindIframeCommunicator: function(iframe, animation) {
+      function sendMessage(requestType, data) {
+        data || (data = {});
+        data.requestType = requestType;
+        data.BFTN_WIDGET_MSG = true;
+        iframe.contentWindow.postMessage(data, '*');
+      }
+
+      var eventMethod = window.addEventListener ? "addEventListener" : "attachEvent";
+      var eventer = window[eventMethod];
+      var messageEvent = eventMethod == "attachEvent" ? "onmessage" : "message";
+
+      eventer(messageEvent, function(e) {
+        if (!e.data || !e.data.BFTN_IFRAME_MSG) return;
+
+        delete e.data.BFTN_IFRAME_MSG;
+
+        switch (e.data.requestType) {
+          case 'getAnimation':
+            iframe.style.display = 'block';
+            sendMessage('putAnimation', animation.options);
+            break;
+          case 'stop':
+            animation.stop();
+            break;
+        }
+      }, false);
+    },
+
+    setCookie: function(name, val, exdays) {
+      var d = new Date();
+      d.setTime(d.getTime()+(exdays*24*60*60*1000));
+
+      var expires = "expires="+d.toGMTString();
+      document.cookie = name + "=" + val + "; " + expires;
+    },
+
+    getCookie: function(cname) {
+      var name = cname + "=";
+      var ca = document.cookie.split(';');
+      var c;
+
+      for(var i = 0; i < ca.length; i++) {
+        c = ca[i].trim();
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
+      }
+
+      return "";
+    },
+
+    log: function() {
+      if (_bftn_options.debug) console.log.apply(console, arguments);
+    }
+  }
+
+  function onDomContentLoaded() {
+    var images = new Array();
+    var preloaded = 0;
+
+    function init() {
+      setTimeout(function() {
+        _bftn_animations[_bftn_options.animation].init(_bftn_options).start();
+      }, _bftn_options.delay);
+    }
+
+    function preload() {
+      for (i = 0; i < preload.arguments.length; i++) {
+        images[i] = new Image()
+        images[i].src = _bftn_options.iframe_base_path + '/images/' + preload.arguments[i]
+
+        images[i].onload = function() {
+          preloaded++;
+          _bftn_util.log('Preloaded ' + preloaded + ' images.');
+
+          if (preloaded == images.length) {
+            _bftn_util.log('DONE PRELOADING IMAGES. Starting animation in ' + _bftn_options.delay + ' milliseconds.');
+            init();
+          }
+        }
+      }
+    }
+
+    // Should we show the widget, regardless?
+    if (!_bftn_options.always_show_widget && window.location.href.indexOf('ALWAYS_SHOW_BFTN_WIDGET') === -1) {
+
+      // Only show once.
+      if (_bftn_util.getCookie('_BFTN_WIDGET_SHOWN')) return;
+
+      // Only show on configured date.
+      var today = new Date();
+      if (today.getFullYear() !== _bftn_options.date.getFullYear() ||
+          today.getMonth() !== _bftn_options.date.getMonth() ||
+          today.getDate() > _bftn_options.date.getDate()) {
+          return;
+      }
+    }
+
+    _bftn_util.setCookie('_BFTN_WIDGET_SHOWN', 'true', 7);
+
+    _bftn_util.injectCSS('_bftn_iframe_css', '#_bftn_wrapper { position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 20000; -webkit-overflow-scrolling: touch; overflow-y: scroll; } #_bftn_iframe { width: 100%; height: 100%;  }');
+
+    // Preload images before showing the animation
+    // preload();
+    init();
+  }
+
+  // Wait for DOM content to load.
+  switch(document.readyState) {
+    case 'complete':
+    case 'loaded':
+    case 'interactive':
+      onDomContentLoaded();
+      break;
+    default:
+      if (typeof document.addEventListener === 'function') {
+        document.addEventListener('DOMContentLoaded', onDomContentLoaded, false);
+      }
+  }
+})();

--- a/public/downloads.html
+++ b/public/downloads.html
@@ -153,7 +153,7 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
           10.9+</a><p>To run Brave, you must have macOS 10.9 or newer.</p>
         </div>
 
-        <div class="col-md-4">
+ <div class="col-md-4">
           <div class="margin-bottom-30">
             <img alt="Brave for Linux" class="responsive" src="assets/img/contents/Linux_icon.png" width="76">
             <h2 class="headline">

--- a/public/index.html
+++ b/public/index.html
@@ -102,8 +102,41 @@ The data-spy and data-target are part of the built-in Bootstrap scrollspy functi
     <!--=== Main content ===-->
     
 
+<!--=== Add widget for Battle For The Net (https://github.com/fightforthefuture/battleforthenet-widget)
+    TODO: Remove this after July 12 2017===-->
+
+    <script type="text/javascript">
+      var _bftn_options = {
+        theme: {
+            className: 'slow',
+            logos: [ 'images/slow.png', 'images/stop.png', 'images/money.png' ],
+            headline: 'This is the web without net neutrality.',
+            body: 'Cable companies are trying to get rid of net neutrality. Without it, sites could be censored, slowed down, or forced to charge fees. Brave wants to keep the Internet open and fast - that\'s why we\'re asking you to contact Congress and the FCC in support of net neutrality.'
+        },
+        delay: 500, // @type {number}
+        org: 'fftf',
+        /*
+         * If you show the modal on your homepage, you should let users close it to
+         * access your site. However, if you launch a new tab to open the modal, closing
+         * the modal just leaves the user staring at a blank page. Set this to true to
+         * prevent closing the modal - the user can close the tab to dismiss it. Defaults
+         * to false.
+         */
+        uncloseable: false, // @type {Boolean}
+        /*
+         * Prevents the widget iframe from loading Google Analytics. Defaults to false.
+         */
+        disableGoogleAnalytics: true, // @type {Boolean}
+        /*
+         * Always show the widget. Useful for testing.
+         */
+        always_show_widget: false // @type {Boolean}
+      };
+    </script>
+    <script src="assets/js/widget.js" async></script>
+
     <!--=== Main content ===-->
-  
+
      <!-- Modal Overlay -->
     <div id="brave-overlay" style="display: none;">
         <div class="close"><i></i><i></i></div>

--- a/server.js
+++ b/server.js
@@ -197,6 +197,7 @@ server.route({
         scriptSrc: '\'unsafe-inline\' *.brave.com \'self\'',
         fontSrc: 'https://fonts.gstatic.com data: \'self\'',
         imgSrc:  '*.brave.com \'self\'',
+        frameSrc: 'https://widget.battleforthenet.com', // REMOVE THIS AFTER 7/12/2017
         // don't generate nonces automatically
         generateNonces: false
       }

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,8 +30,41 @@
 
 {% block mainContent %}
 
+<!--=== Add widget for Battle For The Net (https://github.com/fightforthefuture/battleforthenet-widget)
+    TODO: Remove this after July 12 2017===-->
+
+    <script type="text/javascript">
+      var _bftn_options = {
+        theme: {
+            className: 'slow',
+            logos: [ 'images/slow.png', 'images/stop.png', 'images/money.png' ],
+            headline: 'This is the web without net neutrality.',
+            body: 'Cable companies are trying to get rid of net neutrality. Without it, sites could be censored, slowed down, or forced to charge fees. Brave wants to keep the Internet open and fast - that\'s why we\'re asking you to contact Congress and the FCC in support of net neutrality.'
+        },
+        delay: 500, // @type {number}
+        org: 'fftf',
+        /*
+         * If you show the modal on your homepage, you should let users close it to
+         * access your site. However, if you launch a new tab to open the modal, closing
+         * the modal just leaves the user staring at a blank page. Set this to true to
+         * prevent closing the modal - the user can close the tab to dismiss it. Defaults
+         * to false.
+         */
+        uncloseable: false, // @type {Boolean}
+        /*
+         * Prevents the widget iframe from loading Google Analytics. Defaults to false.
+         */
+        disableGoogleAnalytics: true, // @type {Boolean}
+        /*
+         * Always show the widget. Useful for testing.
+         */
+        always_show_widget: false // @type {Boolean}
+      };
+    </script>
+    <script src="assets/js/widget.js" async></script>
+
     <!--=== Main content ===-->
-  
+
      <!-- Modal Overlay -->
     <div id="brave-overlay" style="display: none;">
         <div class="close"><i></i><i></i></div>


### PR DESCRIPTION
    Add Battle For The Net widget for July 12

    https://github.com/fightforthefuture/battleforthenet-widget

    TODO: Revert this after July 12

    Test plan:
    1. npm start
    2. go to http://localhost:3000/#ALWAYS_SHOW_BFTN_WIDGET and confirm widget appears
    3. clear cookies. go to http://localhost:3000/, confirm widget appears.
    4. visit http://localhost:3000/ again. widget should not appear.
